### PR TITLE
Add WhatsApp audio transcription extension scaffolding

### DIFF
--- a/extension/background/service_worker.js
+++ b/extension/background/service_worker.js
@@ -1,0 +1,87 @@
+async function getApiKey() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(['openaiApiKey'], (result) => {
+      if (chrome.runtime.lastError) {
+        console.error('Erro ao acessar chrome.storage:', chrome.runtime.lastError);
+        resolve(null);
+        return;
+      }
+      resolve(result.openaiApiKey || null);
+    });
+  });
+}
+
+async function callTranscriptionApi(blob, mimeType) {
+  const apiKey = await getApiKey();
+  if (!apiKey) {
+    return {
+      success: false,
+      error: 'Configure a chave da API da OpenAI nas opções da extensão.',
+    };
+  }
+
+  const fileName = `audio-${Date.now()}.webm`;
+  const file = new File([blob], fileName, { type: mimeType || 'audio/webm' });
+
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('model', 'whisper-1');
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Erro ${response.status} na API de transcrição.`;
+      try {
+        const errorData = await response.json();
+        if (errorData && errorData.error && errorData.error.message) {
+          errorMessage = errorData.error.message;
+        }
+      } catch (error) {
+        console.warn('Não foi possível interpretar erro da API:', error);
+      }
+      return { success: false, error: errorMessage };
+    }
+
+    const data = await response.json();
+    return {
+      success: true,
+      transcript: data.text || '',
+    };
+  } catch (error) {
+    console.error('Erro ao chamar a API de transcrição:', error);
+    return {
+      success: false,
+      error: error.message || 'Falha de rede ao contatar a API de transcrição.',
+    };
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || message.action !== 'transcribe-audio') {
+    return;
+  }
+
+  const { blob, mimeType } = message;
+  if (!blob) {
+    sendResponse({ success: false, error: 'Nenhum áudio recebido para transcrição.' });
+    return;
+  }
+
+  callTranscriptionApi(blob, mimeType)
+    .then((result) => {
+      sendResponse(result);
+    })
+    .catch((error) => {
+      console.error('Erro inesperado ao processar transcrição:', error);
+      sendResponse({ success: false, error: error.message || 'Erro inesperado.' });
+    });
+
+  return true;
+});

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,0 +1,149 @@
+(() => {
+  if (window.__waTranscriberButtonInjected) {
+    return;
+  }
+  window.__waTranscriberButtonInjected = true;
+
+  const button = document.createElement('button');
+  button.textContent = 'Transcrever áudio';
+  Object.assign(button.style, {
+    position: 'fixed',
+    right: '24px',
+    bottom: '24px',
+    zIndex: '2147483647',
+    padding: '12px 16px',
+    borderRadius: '999px',
+    border: 'none',
+    backgroundColor: '#25d366',
+    color: '#ffffff',
+    fontSize: '14px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.2)',
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+  });
+
+  button.addEventListener('mouseenter', () => {
+    button.style.transform = 'scale(1.05)';
+    button.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.25)';
+  });
+
+  button.addEventListener('mouseleave', () => {
+    button.style.transform = 'scale(1)';
+    button.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.2)';
+  });
+
+  const toast = document.createElement('div');
+  Object.assign(toast.style, {
+    position: 'fixed',
+    right: '24px',
+    bottom: '84px',
+    maxWidth: '320px',
+    padding: '12px 16px',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(11, 20, 26, 0.95)',
+    color: '#ffffff',
+    fontSize: '13px',
+    lineHeight: '1.4',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+    opacity: '0',
+    transform: 'translateY(10px)',
+    pointerEvents: 'none',
+    transition: 'opacity 0.2s ease, transform 0.2s ease',
+    zIndex: '2147483647',
+  });
+  toast.setAttribute('role', 'status');
+
+  let toastTimeout;
+  function showToast(message, isError = false) {
+    toast.textContent = message;
+    toast.style.backgroundColor = isError ? 'rgba(217, 48, 37, 0.95)' : 'rgba(11, 20, 26, 0.95)';
+    toast.style.opacity = '1';
+    toast.style.transform = 'translateY(0)';
+    clearTimeout(toastTimeout);
+    toastTimeout = setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transform = 'translateY(10px)';
+    }, 4000);
+  }
+
+  async function handleClick() {
+    try {
+      button.disabled = true;
+      button.textContent = 'Buscando áudio…';
+
+      const audios = Array.from(document.querySelectorAll('audio'))
+        .filter((audio) => Boolean(audio.src));
+      const lastAudio = audios[audios.length - 1];
+
+      if (!lastAudio) {
+        showToast('Nenhum áudio encontrado na conversa atual.', true);
+        return;
+      }
+
+      button.textContent = 'Baixando áudio…';
+      const response = await fetch(lastAudio.src);
+      if (!response.ok) {
+        throw new Error('Falha ao baixar o áudio.');
+      }
+
+      const blob = await response.blob();
+      if (!blob || blob.size === 0) {
+        throw new Error('O áudio baixado está vazio.');
+      }
+
+      button.textContent = 'Enviando para transcrição…';
+      const result = await sendMessage({
+        action: 'transcribe-audio',
+        mimeType: blob.type || lastAudio.type || 'audio/ogg',
+        blob,
+      });
+
+      if (!result || !result.success) {
+        const message = result && result.error ? result.error : 'Transcrição não disponível.';
+        throw new Error(message);
+      }
+
+      const transcript = result.transcript || '';
+      let clipboardMessage = '';
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        try {
+          await navigator.clipboard.writeText(transcript);
+          clipboardMessage = ' (copiada para a área de transferência)';
+        } catch (error) {
+          console.warn('Falha ao copiar transcrição:', error);
+        }
+      }
+
+      showToast(`Transcrição pronta${clipboardMessage}: ${transcript}`, false);
+    } catch (error) {
+      console.error('Erro ao transcrever áudio:', error);
+      showToast(error.message || 'Erro inesperado durante a transcrição.', true);
+    } finally {
+      button.disabled = false;
+      button.textContent = 'Transcrever áudio';
+    }
+  }
+
+  function sendMessage(payload) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.runtime.sendMessage(payload, (response) => {
+          const lastError = chrome.runtime.lastError;
+          if (lastError) {
+            reject(new Error(lastError.message));
+            return;
+          }
+          resolve(response);
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  button.addEventListener('click', handleClick);
+
+  document.body.appendChild(button);
+  document.body.appendChild(toast);
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "WhatsApp Audio Transcriber",
+  "version": "1.0.0",
+  "description": "Transcreve rapidamente os áudios da conversa ativa no WhatsApp Web usando a API da OpenAI.",
+  "permissions": ["scripting", "storage", "downloads"],
+  "host_permissions": ["https://web.whatsapp.com/*"],
+  "background": {
+    "service_worker": "background/service_worker.js"
+  },
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["https://web.whatsapp.com/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "Transcrever último áudio"
+  }
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Configurações - WhatsApp Audio Transcriber</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        margin: 0;
+        padding: 24px;
+        background: #f5f6f6;
+        color: #0b141a;
+      }
+      .container {
+        max-width: 420px;
+        margin: 0 auto;
+        background: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 10px 30px rgba(11, 20, 26, 0.1);
+        padding: 24px;
+      }
+      h1 {
+        font-size: 20px;
+        margin: 0 0 16px;
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 8px;
+      }
+      input[type='text'] {
+        width: 100%;
+        padding: 12px;
+        border-radius: 8px;
+        border: 1px solid #d1d7db;
+        font-size: 14px;
+        box-sizing: border-box;
+      }
+      button {
+        margin-top: 16px;
+        width: 100%;
+        padding: 12px;
+        border: none;
+        border-radius: 8px;
+        background: #25d366;
+        color: #ffffff;
+        font-weight: 600;
+        font-size: 15px;
+        cursor: pointer;
+      }
+      button:disabled {
+        background: #b3e7c9;
+        cursor: progress;
+      }
+      .feedback {
+        margin-top: 12px;
+        font-size: 13px;
+        min-height: 18px;
+      }
+      .feedback.success {
+        color: #1da955;
+      }
+      .feedback.error {
+        color: #d93025;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Chave da API OpenAI</h1>
+      <p>Insira abaixo a sua chave para habilitar a transcrição dos áudios.</p>
+      <label for="apiKey">Chave secreta</label>
+      <input type="text" id="apiKey" placeholder="sk-..." autocomplete="off" />
+      <button id="save">Salvar chave</button>
+      <div id="feedback" class="feedback" role="status" aria-live="polite"></div>
+    </div>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,88 @@
+(function () {
+  const apiKeyInput = document.getElementById('apiKey');
+  const saveButton = document.getElementById('save');
+  const feedback = document.getElementById('feedback');
+
+  function setFeedback(message, type) {
+    feedback.textContent = message;
+    feedback.classList.remove('success', 'error');
+    if (type) {
+      feedback.classList.add(type);
+    }
+  }
+
+  function validateKey(key) {
+    if (!key) {
+      return 'Informe uma chave iniciando com sk-.';
+    }
+    const normalized = key.trim();
+    if (!/^sk-[A-Za-z0-9-]{10,}$/.test(normalized)) {
+      return 'Formato de chave inválido. Verifique se está correto (ex: sk-xxxx).';
+    }
+    return null;
+  }
+
+  function getStoredKey() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(['openaiApiKey'], (result) => {
+        if (chrome.runtime.lastError) {
+          console.error('Erro ao carregar chave:', chrome.runtime.lastError);
+          resolve(null);
+          return;
+        }
+        resolve(result.openaiApiKey || null);
+      });
+    });
+  }
+
+  function storeKey(key) {
+    return new Promise((resolve, reject) => {
+      chrome.storage.local.set({ openaiApiKey: key }, () => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  async function init() {
+    setFeedback('Carregando…');
+    const storedKey = await getStoredKey();
+    if (storedKey) {
+      apiKeyInput.value = storedKey;
+      setFeedback('Chave carregada com sucesso.', 'success');
+    } else {
+      setFeedback('');
+    }
+  }
+
+  saveButton.addEventListener('click', async () => {
+    const value = apiKeyInput.value.trim();
+    const validationError = validateKey(value);
+    if (validationError) {
+      setFeedback(validationError, 'error');
+      return;
+    }
+
+    saveButton.disabled = true;
+    setFeedback('Salvando…');
+
+    try {
+      await storeKey(value);
+      setFeedback('Chave salva com sucesso!', 'success');
+    } catch (error) {
+      console.error('Erro ao salvar chave:', error);
+      setFeedback('Não foi possível salvar a chave. Tente novamente.', 'error');
+    } finally {
+      saveButton.disabled = false;
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add Chrome extension manifest with permissions, background worker, content script, and options page
- inject floating button on WhatsApp Web to download the latest audio, send it for transcription, and surface the result with toasts and clipboard copy
- implement background service worker that loads the stored OpenAI API key and calls the Whisper transcription endpoint
- build options UI to save the OpenAI API key securely in chrome.storage with basic validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d32c016dac832f9353405874e303f3