### PR TITLE
Open options page on initial install

### DIFF
--- a/extension/background/service_worker.js
+++ b/extension/background/service_worker.js
@@ -85,3 +85,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   return true;
 });
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    chrome.runtime.openOptionsPage();
+  }
+});


### PR DESCRIPTION
## Summary
- open the options page when the extension is installed for the first time

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3352d38a4832fb7c04901f516752d