### PR TITLE
Add OpenAI API host permission

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Transcreve rapidamente os áudios da conversa ativa no WhatsApp Web usando a API da OpenAI.",
   "permissions": ["scripting", "storage", "downloads"],
-  "host_permissions": ["https://web.whatsapp.com/*"],
+  "host_permissions": ["https://web.whatsapp.com/*", "https://api.openai.com/*"],
   "background": {
     "service_worker": "background/service_worker.js"
   },


### PR DESCRIPTION
## Summary
- add https://api.openai.com/* to the extension host permissions to allow API access

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3352fc650832fb3091aec15210b05